### PR TITLE
Next set of questions remember answers

### DIFF
--- a/app/views/sprint-5/mat-billing-information.html
+++ b/app/views/sprint-5/mat-billing-information.html
@@ -94,7 +94,7 @@
         }) }}
         {% endset -%}
 
-    
+
 
         {{ govukRadios({
           name: "invoiceType",

--- a/app/views/sprint-5/mat-site-contact.html
+++ b/app/views/sprint-5/mat-site-contact.html
@@ -30,28 +30,28 @@
           <label class="govuk-label" for="scontact-firstname">
             First name
           </label>
-          <input class="govuk-input govuk-input--width-20" id="scontact-firstname" name="scontact-firstname" type="text">
+          <input class="govuk-input govuk-input--width-20" id="scontact-firstname" name="scontact-firstname" type="text" value="{{data['scontact-firstname']}}">
         </div>
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="scontact-lastname">
             Last name
           </label>
-          <input class="govuk-input govuk-input--width-20" id="scontact-lastname" name="scontact-lastname" type="text">
+          <input class="govuk-input govuk-input--width-20" id="scontact-lastname" name="scontact-lastname" type="text" value="{{data['scontact-lastname']}}">
         </div>
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="scontact-email">
             Email
           </label>
-          <input class="govuk-input govuk-input--width-20" id="scontact-email" name="scontact-email" type="text">
+          <input class="govuk-input govuk-input--width-20" id="scontact-email" name="scontact-email" type="text" value="{{data['scontact-email']}}">
         </div>
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="scontact-tel">
             Telephone
           </label>
-          <input class="govuk-input govuk-input--width-20" id="scontact-tel" name="scontact-tel" type="text">
+          <input class="govuk-input govuk-input--width-20" id="scontact-tel" name="scontact-tel" type="text" value="{{data['scontact-tel']}}" >
         </div>
 
         {{ govukButton({

--- a/app/views/sprint-5/mat-vat-contact-manual.html
+++ b/app/views/sprint-5/mat-vat-contact-manual.html
@@ -30,13 +30,13 @@
             <label class="govuk-label" for="vatname">
               Name
             </label>
-            <input class="govuk-input govuk-!-width-two-thirds" id="vatname" name="vatname" type="text" autocomplete="vatname">
+            <input class="govuk-input govuk-!-width-two-thirds" id="vatname" name="vatname" type="text" autocomplete="vatname" value="{{data['vatname']}}">
           </div>
           <div class="govuk-form-group">
             <label class="govuk-label" for="vattel">
               Telephone number
             </label>
-            <input class="govuk-input govuk-!-width-two-thirds" id="vattel" name="vattel" type="text" autocomplete="vattel">
+            <input class="govuk-input govuk-!-width-two-thirds" id="vattel" name="vattel" type="text" autocomplete="vattel" value="{{data['vattel']}}">
           </div>
         </fieldset>
 
@@ -52,15 +52,21 @@
           items: [
             {
               value: "Address 1",
-              text: "Address 1"
+              text: "Address 1",
+              checked: {
+                html: data['Address 1']
+              }
             },
             {
               value: "Address 2",
-              text: "Address 2"
+              text: "Address 2",
+              checked: {
+                html: data['Address 2']
+              }
             },
             {
-              value: "Address 2",
-              text: "Address 2"
+              value: "Address 3",
+              text: "Address 3"
             }
           ]
         }) }}

--- a/app/views/sprint-5/mat-vat-contact.html
+++ b/app/views/sprint-5/mat-vat-contact.html
@@ -72,7 +72,7 @@
           text: "Save and continue",
           href: ""
         }) }}
-        
+
         {{ govukButton({
           text: "Save and go to tasks",
           href: "/sprint-5/tasklist",

--- a/app/views/sprint-5/mat-vat-declaration.html
+++ b/app/views/sprint-5/mat-vat-declaration.html
@@ -40,6 +40,7 @@
           suffix: {
             text: "%"
           },
+          value: data['vat-num'],
           spellcheck: false
         }) }}
         {% endset -%}
@@ -52,7 +53,7 @@
             }
           },
           hint: {
-            text: "If you’re unsure, check your energy bills or ask your local authority"
+            text: "If you're unsure, check your energy bills or ask your local authority"
           },
           items: [
             {
@@ -60,6 +61,9 @@
               text: "20%",
               conditional: {
                 html: 20vatHtml
+              },
+              checked: {
+                html: data['20%']
               }
             },
             {
@@ -67,12 +71,15 @@
               text: "5%",
               conditional: {
                 html: textHtml
+              },
+              checked: {
+                html: data['5%']
               }
             }
           ]
         }) }}
 
-       
+
 
         {{ govukButton({
           text: "Save and continue"

--- a/app/views/sprint-5/mat-vat-status.html
+++ b/app/views/sprint-5/mat-vat-status.html
@@ -29,13 +29,13 @@
             </legend>
             <div class="govuk-radios" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="VATstatus" name="VATstatus" type="radio" value="yes">
+                <input class="govuk-radios__input" id="VATstatus" name="VATstatus" type="radio" value="yes" {{ checked("VATstatus", "yes") }}>
                 <label class="govuk-label govuk-radios__label" for="whereDoYouLive">
                   Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="VATstatus-2" name="VATstatus" type="radio" value="no~/sprint-5/mat-billing-setup?vatd=">
+                <input class="govuk-radios__input" id="VATstatus-2" name="VATstatus" type="radio" value="no~/sprint-5/mat-billing-setup?vatd=" {{ checked("VATstatus", "no") }}>
                 <label class="govuk-label govuk-radios__label" for="VATstatus-2">
                   No
                 </label>
@@ -43,7 +43,7 @@
             </div>
           </fieldset>
         </div>
-        
+
 
         {{ govukButton({
           text: "Save and continue"

--- a/app/views/sprint-5/vat-certificate.html
+++ b/app/views/sprint-5/vat-certificate.html
@@ -34,21 +34,21 @@
         <div class="govuk-form-group">
         <div class="govuk-checkboxes" data-module="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="dec" name="declaration" type="checkbox" value="dec">
+            <input class="govuk-checkboxes__input" id="dec" name="declaration" type="checkbox" value="dec" {{ checked("declaration", "dec") }}>
             <label class="govuk-label govuk-checkboxes__label" for="dec">
               I certify that the information given is correct and complete
             </label>
           </div>
           <br>
           <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="dec-1" name="declaration" type="checkbox" value="dec-1">
+            <input class="govuk-checkboxes__input" id="dec-1" name="declaration" type="checkbox" value="dec-1" {{ checked("declaration", "dec-1") }}>
             <label class="govuk-label govuk-checkboxes__label" for="dec-1">
               I undertake to inform the supplier of any change in the qualifying use
             </label>
           </div>
           <br>
           <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="dec-2" name="declaration" type="checkbox" value="dec-2">
+            <input class="govuk-checkboxes__input" id="dec-2" name="declaration" type="checkbox" value="dec-2" {{ checked("declaration", "dec-2") }}>
             <label class="govuk-label govuk-checkboxes__label" for="dec-2">
               I understand that any incorrect statement may make me liable for a financial penalty under the Value Added Tax Act (as amended from time to time)
             </label>


### PR DESCRIPTION
Looks like the nunjucks radios and other components do not want to remember their answers. I tried adding in the relevant code but it just adds a checked property to all e.g. radios so the last one in the group is checked

With html there is some logic that can be put on to see if there is a value with a given property set e.g. schoolType=MAT and if so check this radio. There must be some way to do this with  nunjucks but I'm not sure how to do this right now.

Could either convert them to html at some point or dig into this a bit more later on.