### PR TITLE
Es784 update prototype directory

### DIFF
--- a/app/views/single-schools/elec-meter-info.html
+++ b/app/views/single-schools/elec-meter-info.html
@@ -82,7 +82,7 @@
               </div>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="halfHour-2" name="halfHour" type="radio" value="No" aria-describedby="halfHour-2-item-hint">
+              <input class="govuk-radios__input" id="halfHour-2" name="halfHour" type="radio" value="No" aria-describedby="halfHour-2-item-hint" checked="{{ checked('halfHour', 'No') }}">
               <label class="govuk-label govuk-radios__label" for="halfHour-2">
                 No
               </label>

--- a/app/views/single-schools/listings.html
+++ b/app/views/single-schools/listings.html
@@ -1,92 +1,102 @@
 {% extends "layouts/main-branding-2025.html" %}
 
 {% block pageTitle %}
-  Content page template – {{ serviceName }} – GOV.UK Prototype Kit
+  {{ serviceName }} – Page by page listings
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-    href: "javascript:window.history.back()"
-  }) }}
+  {{ govukBackLink({text: "Back",href: "javascript:window.history.back()"}) }}
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      <h1 class="govuk-heading-l">
-        Page by page listings
-      </h1>
-
-      <p class="govuk-body-s">Last updated 13 May 2025</p>
-      <p><a href="/admin/data">Data been stored as part of current session</a></p>
+      <h1 class="govuk-heading-l">Page by page listings</h1>
+      <p><a href="/admin/data">Data that has been stored as part of current
+        session</a></p>
       <p><a href="/manage-prototype/clear-data">Clear data</a></p>
-
       <h2 class="govuk-heading-l">DfE sign in</h2>
           <ul class="govuk-list govuk-list--bullet">
-              <li><a class="govuk-link" href="/sprint-5/start-page" >Start page</a></li>
-              <li><a class="govuk-link" href="/sprint-5/guidance-page" >Guidance page</a></li>
-              <li><a class="govuk-link" href="/sprint-5/before-you-start" >Before you start</a></li>
-              <li><a class="govuk-link" href="/sprint-5/request-for-help-email" >Do you have a DfE sign in account?</a></li>
-              <li><a class="govuk-link" href="/sprint-5/dfe-sign-in-email" >DfE sign in email</a></li>
-              <li><a class="govuk-link" href="/sprint-5/dfe-sign-in-password" >DfE sign in password</a></li>
-              <li><a class="govuk-link" href="/sprint-5/which-school-are-you-buying-for" >DfE school selection</a></li>
-              <li><a class="govuk-link" href="/sprint-5/pilot-service-only-single-schools" >Pilot Trust/MAT error</a></li>
+              <li><a class="govuk-link" href="/single-schools/start-page">Start
+                page</a></li>
+              <li><a class="govuk-link" href="/single-schools/guidance-page">
+                Guidance page</a></li>
+              <li><a class="govuk-link" href="/single-schools/before-you-start">
+                Before you start</a></li>
+              <li><a class="govuk-link" href="/single-schools/request-for-help-email">
+                Do you have a DfE sign in account?</a></li>
+              <li><a class="govuk-link" href="/single-schools/dfe-sign-in-email">
+                DfE sign in email</a></li>
+              <li><a class="govuk-link" href="/single-schools/dfe-sign-in-password">
+                DfE sign in password</a></li>
+              <li><a class="govuk-link" href="/single-schools/which-school-are-you-buying-for">
+                DfE school selection</a></li>
+              <li><a class="govuk-link" href="/single-schools/pilot-service-only-single-schools">
+                Pilot Trust/MAT error</a></li>
           </ul>
-
           <h2 class="govuk-heading-l">On boarding form</h2>
           <ul class="govuk-list govuk-list--bullet">
-              <li><a class="govuk-link" href="/sprint-5/single-school-fuel-selection" >School fuel selection</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-authorisation" >Authroisation</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-existing-contracts" >Contracts set up</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-existing-contracts-gas" >Existing contracts gas</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-existing-contracts-electric" >Existing contracts electric</a></li>
-              <li><a class="govuk-link" href="/sprint-5/tasklist" >Tasklist</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-gas-contract" >Gas contract</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-electricity-contract" >Electricity contract</a></li>
-              <!-- <li><a class="govuk-link" href="/sprint-5/mat-gas-contract-combined-contract" >Combined Energy contract</a></li> -->
-              <li><a class="govuk-link" href="/sprint-5/mat-vat-status" >Do all schools in the trust use the same VAT number?</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-vat-declaration" >VAT declaration</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-vat-contact" >VAT contact</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-vat-contact-manual" >VAT declaration manual</a></li>
-              <li><a class="govuk-link" href="/sprint-5/vat-certificate" >VAT certificate</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-billing-setup" >Billing setup</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-billing-information" >Billing information</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-billing-contact" >Billing contact</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-billing-contact-manual" >Billing contact manual</a></li>
-              <li><a class="govuk-link" href="/sprint-5/gas-info" >Gas Multi or Single meter</a></li>
-              <li><a class="govuk-link" href="/sprint-5/gas-meter-info" >Gas Meter readings</a></li>
-              <li><a class="govuk-link" href="/sprint-5/gas-meter-review" >Gas Review MPRNs and readings</a></li>
-              <li><a class="govuk-link" href="/sprint-5/remove-mprn" >Remove MPRN</a></li>
-              <li><a class="govuk-link" href="/sprint-5/multi-meter-prompt" >Multi meter prompt</a></li>
-              <li><a class="govuk-link" href="/sprint-5/gas-info-billing" >Gas billing info</a></li>
-              <li><a class="govuk-link" href="/sprint-5/elec-info" >Electric Multi or Single meter</a></li>
-              <li><a class="govuk-link" href="/sprint-5/elec-meter-info" >Electric Meter readings</a></li>
-              <li><a class="govuk-link" href="/sprint-5/elec-meter-review" >Electric Review MPANs and readings</a></li>
-              <li><a class="govuk-link" href="/sprint-5/elec-info-billing" >Electric billing info</a></li>
-              <li><a class="govuk-link" href="/sprint-5/mat-site-contact" >Site contact</a></li>
-              <li><a class="govuk-link" href="/sprint-5/check-answers-mat" >Check answers MAT</a></li>
-              <li><a class="govuk-link" href="/sprint-5/check-answers-single-school" >Check answers Single school</a></li>
-              <li><a class="govuk-link" href="/sprint-5/authorisation" >Declaration</a></li>
-              <li><a class="govuk-link" href="/sprint-5/confirmation" >Confirmation page</a></li>
+              <li><a class="govuk-link" href="/single-schools/single-school-fuel-selection">
+                Are you switching electricity, gas or both?</a></li>
+              <li><a class="govuk-link" href="/single-schools/tasklist">
+                Tasklist</a></li>
+              <li><a class="govuk-link" href="/single-schools/vat-certificate">
+                VAT certificate</a></li>
+              <li><a class="govuk-link" href="/single-schools/gas-info">
+                Gas Multi or Single meter</a></li>
+              <li><a class="govuk-link" href="/single-schools/gas-meter-info">
+                Gas Meter readings</a></li>
+              <li><a class="govuk-link" href="/single-schools/gas-meter-review">
+                Gas Review MPRNs and readings</a></li>
+              <li><a class="govuk-link" href="/single-schools/remove-mprn">
+                Remove MPRN</a></li>
+              <li><a class="govuk-link" href="/single-schools/multi-meter-prompt">
+                Multi meter prompt</a></li>
+              <li><a class="govuk-link" href="/single-schools/gas-info-billing">
+                Gas billing info</a></li>
+              <li><a class="govuk-link" href="/single-schools/elec-info">
+                Electric Multi or Single meter</a></li>
+              <li><a class="govuk-link" href="/single-schools/elec-meter-info">
+                Electric Meter readings</a></li>
+              <li><a class="govuk-link" href="/single-schools/elec-meter-review">
+                Electric Review MPANs and readings</a></li>
+              <li><a class="govuk-link" href="/single-schools/elec-info-billing">
+                Electric billing info</a></li>
+              <li><a class="govuk-link" href="/single-schools/mat-site-contact">
+                Site contact</a></li>
+              <li><a class="govuk-link" href="/single-schools/check-answers-single-school">
+                Check answers</a></li>
+              <li><a class="govuk-link" href="/single-schools/authorisation">
+                Declaration</a></li>
+              <li><a class="govuk-link" href="/single-schools/confirmation">
+                Confirmation page</a></li>
           </ul>
-
           <h2 class="govuk-heading-l">Support journeys</h2>
           <ul class="govuk-list govuk-list--bullet">
-            <li><a class="govuk-link" href="/sprint-5/support/request-for-help-email" >Do you have a DfE Sign-in account linked to the school</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/what-type-of-org" >What type of organisation</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/school-search" >Search for school</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/is-this-your-school" >Is this the school you’re buying for?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/which-schools-list" >(Sign in) MATS Is this the school you’re buying for?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/what-is-your-name" >What is your name?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/what-is-your-email" >What is your email address?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/how-can-we-help" >How can we help?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/accessibility-needs" >Do you have any access needs?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/how-did-you-find-out-about-this-service" >How did you find this service?</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/send-your-request" >Send your request</a></li>
-            <li><a class="govuk-link" href="/sprint-5/support/confirmation" >Confirmation</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/request-for-help-email">
+              Do you have a DfE Sign-in account linked to the school</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/what-type-of-org">
+              What type of organisation</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/school-search">
+              Search for school</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/is-this-your-school">
+              Is this the school you're buying for?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/which-schools-list">
+              (Sign in) MATS Is this the school you're buying for?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/what-is-your-name">
+              What is your name?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/what-is-your-email">
+              What is your email address?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/how-can-we-help">
+              How can we help?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/accessibility-needs">
+              Do you have any access needs?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/how-did-you-find-out-about-this-service">
+              How did you find this service?</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/send-your-request">
+              Send your request</a></li>
+            <li><a class="govuk-link" href="/single-schools/support/confirmation">
+              Confirmation</a></li>
           </ul>
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "2.0.1",
         "dfe-frontend": "^2.0.1",
-        "govuk-frontend": "5.11.1",
+        "govuk-frontend": "5.11.2",
         "govuk-prototype-kit": "13.18.0",
         "jquery": "3.7.1",
         "radio-button-redirect": "^1.2.0"
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
-      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
+      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
     "dfe-frontend": "^2.0.1",
-    "govuk-frontend": "5.11.1",
+    "govuk-frontend": "5.11.2",
     "govuk-prototype-kit": "13.18.0",
     "jquery": "3.7.1",
     "radio-button-redirect": "^1.2.0"


### PR DESCRIPTION
Update listings page for single school journey to use new single-schools URL
Remove obvious MAT listings

NOTE a bunch of MAT pages are used in the single school journey for reasons that must exist but I am not aware of. At some point we should look to making the single school journey only use single school pages as it makes it very hard to unpick what is used with what journey.